### PR TITLE
Configurable way to warn if translation does not exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,15 @@
+'use strict';
 var IntlMixin = require('react-intl').IntlMixin;
 
 var IntlHelperMixin = {
 
     mixins : [IntlMixin],
+
+    /**
+     * Defines if mixin should warn if a translation does not exist for a string
+     * On by default
+     */
+    warnOnNoTranslation : true,
 
     /**
      * Translate function that returns a message from the intl file.
@@ -29,8 +36,12 @@ var IntlHelperMixin = {
         }
 
         // if a message was not found, return the end of the path
+        if (this.warnOnNoTranslation) {
+            console.warn('Missing translation for: ' + path);
+        }
+
         var pathParts = path.split('.');
-        return pathParts[pathParts.length-1];
+        return pathParts[pathParts.length - 1];
     },
 
     /**
@@ -46,11 +57,11 @@ var IntlHelperMixin = {
     getValidationMessagesForKey : function(messages, key, translatePath, status)
     {
         var component = this;
-        var status    = status || 'error';
+        var statusValue    = status || 'error';
 
         if (typeof messages[key] !== 'undefined') {
             return {
-                status   : status,
+                status   : statusValue,
                 messages : _.map(messages[key], function(constant) {
                     return component.t(translatePath + '.' + key + '.' + constant);
                 })
@@ -79,6 +90,6 @@ var IntlHelperMixin = {
             return false;
         }
     }
-}
+};
 
 module.exports = IntlHelperMixin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,8 +48,8 @@ var IntlHelperMixin = {
      */
     getValidationMessagesForKey : function(messages, key, translatePath, status)
     {
-        var component = this;
-        var statusValue    = status || 'error';
+        var component   = this;
+        var statusValue = status || 'error';
 
         if (typeof messages[key] !== 'undefined') {
             return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,6 @@ var IntlHelperMixin = {
     mixins : [IntlMixin],
 
     /**
-     * Defines if mixin should warn if a translation does not exist for a string
-     * On by default
-     */
-    warnOnNoTranslation : true,
-
-    /**
      * Translate function that returns a message from the intl file.
      * The message returned is dependent on the language of the browser.
      * Defaults to en-us if the message doesn't exist for the current language.
@@ -36,9 +30,7 @@ var IntlHelperMixin = {
         }
 
         // if a message was not found, return the end of the path
-        if (this.warnOnNoTranslation) {
-            console.warn('Missing translation for: ' + path);
-        }
+        console.warn('Missing translation for: ' + path);
 
         var pathParts = path.split('.');
         return pathParts[pathParts.length - 1];


### PR DESCRIPTION
## As a developer, I should be warned in the console if a translation does not exist for a key
### Acceptance Criteria
1. warning in console if translation doesn't exist
### Tasks
- {{list developer tasks here}}
### Additional Notes
- {{list additional notes here, remove if not applicable}}
